### PR TITLE
Fix: Switch to GitHub Actions for Pages

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,42 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem
Legacy Pages build system showing 'errored' status and stuck building for 15+ minutes.

## Solution
Switch to GitHub Actions deployment workflow (recommended modern approach).

## Benefits
- ✅ More reliable builds
- ✅ Faster deployment (~30 seconds)
- ✅ Better error reporting in Actions tab
- ✅ Industry standard workflow

## Required: Manual Settings Change
After merging, you must update Pages settings:

1. Go to: https://github.com/jonschull/ERA_Admin/settings/pages
2. Source: Change from 'Deploy from branch' → **'GitHub Actions'**
3. Save

Then the workflow will trigger automatically on next push to main.