### PR TITLE
Fix: Exclude Python artifacts from Pages deployment

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,11 +32,21 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Create deployment directory
+        run: |
+          mkdir -p _site
+          # Copy only necessary files (exclude Python cache, venv, etc.)
+          rsync -av --exclude='__pycache__' \
+                    --exclude='*.pyc' \
+                    --exclude='venv' \
+                    --exclude='historical/venv' \
+                    --exclude='.git' \
+                    --exclude='.github' \
+                    . _site/
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          path: '_site'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Fixes artifact upload failure.

**Changes:**
- Use rsync to copy files excluding Python artifacts
- Exclude: __pycache__, *.pyc, venv, .git, .github
- Deploy from _site directory with only necessary static content

This resolves the 'Upload artifact' step failure in Actions.