### PR TITLE
Fix: Reduce Town Hall node size

### DIFF
--- a/ERA_Landscape/index.html
+++ b/ERA_Landscape/index.html
@@ -669,8 +669,8 @@
         
         let finalValue;
         if (type === 'event') {
-          // Events scale minimally, with nodeSize multiplier
-          finalValue = Math.min(connections * 0.3, 10) * (typeof networkConfig !== 'undefined' ? networkConfig.nodeSize : 1.0);
+          // Events scale minimally, with nodeSize multiplier (capped at 4 to keep small)
+          finalValue = Math.min(connections * 0.3, 4) * (typeof networkConfig !== 'undefined' ? networkConfig.nodeSize : 1.0);
         } else {
           // Regular nodes: apply scaling intensity formula
           const constantScale = 10;
@@ -1177,10 +1177,10 @@
       const type = parseTypeFromId(node.id);
       
       if (type === 'event') {
-        // Events scale minimally, but still respect nodeSize multiplier
+        // Events scale minimally, but still respect nodeSize multiplier (capped at 4 to keep small)
         return {
           ...node,
-          value: Math.min(connections * 0.3, 10) * networkConfig.nodeSize
+          value: Math.min(connections * 0.3, 4) * networkConfig.nodeSize
         };
       }
       


### PR DESCRIPTION
Town Halls were too large because they had many 'attended' edges, hitting the event size cap of 10.

**Change:** Reduced event node size cap from 10 to 4

**Before:** Town Halls sized up to value 10 (very large hexagons)  
**After:** Town Halls capped at value 4 (compact hexagons)

**Files:** `ERA_Landscape/index.html` (2 locations where event size is calculated)