### PR TITLE
docs: Add local pre-commit hook for branch protection

### DIFF
--- a/WORKING_PRINCIPLES.md
+++ b/WORKING_PRINCIPLES.md
@@ -194,11 +194,38 @@ The content below in Section 4 contains all the principles. They are organized i
 - Check before commit: `git status`, look for sensitive files
 - Use `.gitignore` patterns for generated files
 
-**Enforcement: Branch Protection**
+**Enforcement: Branch Protection (Two Layers)**
 
-Documentation alone is insufficient. Use GitHub branch protection to technically enforce PR protocol:
+Documentation alone is insufficient. Enforce PR protocol at both local and remote:
 
-*Setup (one-time):*
+*Layer 1: Local Pre-Commit Hook (blocks commits before they happen)*
+
+After cloning, install the pre-commit hook:
+```bash
+cat > .git/hooks/pre-commit << 'EOF'
+#!/bin/bash
+branch=$(git symbolic-ref HEAD 2>/dev/null | sed 's!refs/heads/!!')
+if [ "$branch" = "main" ]; then
+    cat << 'MSG'
+❌ ERROR: Direct commits to 'main' branch are not allowed
+
+✅ Proper workflow:
+   1. Create feature branch: git checkout -b feature/description
+   2. Make commits on that branch
+   3. Create PR: gh pr create
+   4. After merge: git checkout main && git pull
+
+See WORKING_PRINCIPLES.md Section 4 (Git & PR Practices)
+MSG
+    exit 1
+fi
+EOF
+chmod +x .git/hooks/pre-commit
+```
+
+*Layer 2: GitHub Branch Protection (blocks pushes)*
+
+Setup (one-time):
 ```bash
 # Via GitHub CLI:
 gh api repos/OWNER/REPO/branches/main/protection -X PUT --input - << 'EOF'
@@ -220,7 +247,7 @@ EOF
 4. Check: "Include administrators" (enforces for everyone)
 5. Set required approvals to 0 (for solo work)
 
-*Result:* Direct commits to main become technically impossible.
+*Result:* Direct commits to main blocked locally; pushes blocked remotely.
 
 **Living Documents**
 


### PR DESCRIPTION
Prevents the 41-commit-to-main problem from happening again.

See commit message for details.

Follow-up to PR #18 cleanup.